### PR TITLE
Adding cinder-volume container check commands

### DIFF
--- a/roles/overclould_containers_sanity/files/container_sanity.py
+++ b/roles/overclould_containers_sanity/files/container_sanity.py
@@ -81,6 +81,9 @@ def check_docker_container_volume(node):
 def container2dict(container):
     if "cron" in container:
         return {'cmd': "ps -aux", 'process': "crond"}
+    
+    if "openstack-cinder-volume-docker" in container:
+        return {'cmd': "ps -aux", 'process': "cinder-volume"}
 
     switcher = {
         "horizon": {'cmd': "ps -aux", 'process': "httpd"},


### PR DESCRIPTION
Using InfraRed to deploy overcloud fails on the post_tasks step with the assertion error as it runs incorrect command on the openstack-cinder-volume-docker-0 container. This patch attempts to run the correct command on that container.